### PR TITLE
Validate category for new transactions

### DIFF
--- a/src/finance_tracker/services/transaction_service.py
+++ b/src/finance_tracker/services/transaction_service.py
@@ -21,7 +21,13 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from pydantic import ValidationError
 
-from finance_tracker.models import TransactionDB, TransactionCreate, TransactionType, TransactionUpdate
+from finance_tracker.models import (
+    CategoryDB,
+    TransactionDB,
+    TransactionCreate,
+    TransactionType,
+    TransactionUpdate,
+)
 from finance_tracker.utils.validation import validate_uuid_format
 
 
@@ -146,7 +152,18 @@ def create_transaction(session: Session, transaction: TransactionCreate) -> Tran
             raise ValueError(error_msg)
         
         validate_uuid_format(transaction.category_id, "category_id")
-        
+
+        category = session.query(CategoryDB).filter_by(id=transaction.category_id).first()
+        if not category:
+            error_msg = "Категория с указанным ID не найдена"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        if category.type != transaction.type:
+            error_msg = "Тип категории не соответствует типу транзакции"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
         # Создаём объект БД из Pydantic модели
         db_transaction = TransactionDB(**transaction.model_dump())
         


### PR DESCRIPTION
### Motivation
- Prevent creating transactions referencing missing or mismatched categories by validating the category before persisting the transaction.

### Description
- Add `CategoryDB` import to `src/finance_tracker/services/transaction_service.py`.
- After `validate_uuid_format(transaction.category_id, "category_id")`, query the DB for `CategoryDB` by `transaction.category_id` and raise `ValueError` with a clear message if not found.
- If the category exists but `category.type != transaction.type`, raise `ValueError` with a clear message and log the error.
- Ensure these category existence and type checks run before constructing and committing the `TransactionDB` object.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b4bb879a0832595d63e9942617417)